### PR TITLE
A couple of tweaks

### DIFF
--- a/nextSongPuck.js
+++ b/nextSongPuck.js
@@ -2,18 +2,18 @@ let counter = 0;
 let connected = false;
 let controls = require("ble_hid_controls");
 
-NRF.setServices(undefined, { hid : controls.report });
+NRF.setServices(undefined, { hid: controls.report });
 
 function single() {
   if (connected) {
     digitalWrite(LED3, true);
-    setTimeout(function(){				//Confirm with green blink
+    setTimeout(function() { //Confirm with green blink
       digitalWrite(LED3, false);
     }, 500);
-    controls.next();					// Skip to next song
+    controls.next(); // Skip to next song
   } else {
     digitalWrite(LED1, true);
-    setTimeout(function(){				//Red blink as error message when not connected
+    setTimeout(function() { //Red blink as error message when not connected
       digitalWrite(LED1, false);
     }, 500);
   }
@@ -22,13 +22,13 @@ function single() {
 function double() {
   if (connected) {
     digitalWrite(LED3, true);
-    setTimeout(function(){
+    setTimeout(function() {
       digitalWrite(LED3, false);
     }, 500);
-    controls.playpause();				// Play/stop music
+    controls.playpause(); // Play/stop music
   } else {
     digitalWrite(LED1, true);
-    setTimeout(function(){
+    setTimeout(function() {
       digitalWrite(LED1, false);
     }, 500);
   }
@@ -37,38 +37,38 @@ function double() {
 function tripple() {
   if (connected) {
     digitalWrite(LED3, true);
-    setTimeout(function(){
+    setTimeout(function() {
       digitalWrite(LED3, false);
     }, 500);
-    controls.prev();					// Go to previous song
+    controls.prev(); // Go to previous song
   } else {
     digitalWrite(LED1, true);
-    setTimeout(function(){
+    setTimeout(function() {
       digitalWrite(LED1, false);
     }, 500);
   }
 }
 
 NRF.on('connect', function(addr) {
-    connected = true;
-    digitalWrite(LED2, true);			//confirm successfull connection with green blink
-    setTimeout(function(){
-      digitalWrite(LED2, false);
-    }, 500);
+  connected = true;
+  digitalWrite(LED2, true); //confirm successfull connection with green blink
+  setTimeout(function() {
+    digitalWrite(LED2, false);
+  }, 500);
 });
 
-NRF.on('disconnect', function(reason) { 
-    connected = false;  				//reset everything on disconnect
-    digitalWrite(LED1, false);
-    digitalWrite(LED2, false);
-    digitalWrite(LED3, false);
+NRF.on('disconnect', function(reason) {
+  connected = false; //reset everything on disconnect
+  digitalWrite(LED1, false);
+  digitalWrite(LED2, false);
+  digitalWrite(LED3, false);
 });
 
 //trigger buttonEvaluation whenever the button is pressed
 let watchID = setWatch(function buttonEvaluation() {
-  let evalDuration = 600;			//wait for 2nd or 3rd button press before evaluating counter
+  let evalDuration = 600; //wait for 2nd or 3rd button press before evaluating counter
   counter++;
-  setTimeout(()=>{
+  setTimeout(() => {
     if (counter === 3) {
       tripple();
       counter = 0;
@@ -82,4 +82,4 @@ let watchID = setWatch(function buttonEvaluation() {
       counter = 0;
     }
   }, evalDuration);
-}, BTN, {edge:"rising", debounce:5, repeat:true});
+}, BTN, { edge: "rising", debounce: 5, repeat: true });

--- a/nextSongPuck.js
+++ b/nextSongPuck.js
@@ -9,57 +9,36 @@ let config = {
 
 NRF.setServices(undefined, { hid: controls.report });
 
-function next() {
+function flash(led) {
+  digitalWrite(led, true);
+  setTimeout(function () {
+    digitalWrite(led, false);
+  }, 500);
+}
+function flashAndCall(cb) {
   if (connected) {
-    digitalWrite(LED3, true);
-    setTimeout(function() { //Confirm with green blink
-      digitalWrite(LED3, false);
-    }, 500);
-    controls.next(); // Skip to next song
+    flash(LED3);
+    cb();
   } else {
-    digitalWrite(LED1, true);
-    setTimeout(function() { //Red blink as error message when not connected
-      digitalWrite(LED1, false);
-    }, 500);
+    flash(LED1);
   }
+}
+
+function next() {
+  flashAndCall(controls.next);
 }
 
 function playpause() {
-  if (connected) {
-    digitalWrite(LED3, true);
-    setTimeout(function() {
-      digitalWrite(LED3, false);
-    }, 500);
-    controls.playpause(); // Play/stop music
-  } else {
-    digitalWrite(LED1, true);
-    setTimeout(function() {
-      digitalWrite(LED1, false);
-    }, 500);
-  }
+  flashAndCall(controls.playpause);
 }
 
 function previous() {
-  if (connected) {
-    digitalWrite(LED3, true);
-    setTimeout(function() {
-      digitalWrite(LED3, false);
-    }, 500);
-    controls.prev(); // Go to previous song
-  } else {
-    digitalWrite(LED1, true);
-    setTimeout(function() {
-      digitalWrite(LED1, false);
-    }, 500);
-  }
+  flashAndCall(controls.prev);
 }
 
 NRF.on('connect', function(addr) {
   connected = true;
-  digitalWrite(LED2, true); //confirm successfull connection with green blink
-  setTimeout(function() {
-    digitalWrite(LED2, false);
-  }, 500);
+  flash(LED2);
 });
 
 NRF.on('disconnect', function(reason) {

--- a/nextSongPuck.js
+++ b/nextSongPuck.js
@@ -34,7 +34,7 @@ function double() {
   }
 }
 
-function tripple() {
+function triple() {
   if (connected) {
     digitalWrite(LED3, true);
     setTimeout(function() {
@@ -70,7 +70,7 @@ let watchID = setWatch(function buttonEvaluation() {
   counter++;
   setTimeout(() => {
     if (counter === 3) {
-      tripple();
+      triple();
       counter = 0;
     } else if (counter === 2) {
       double();

--- a/nextSongPuck.js
+++ b/nextSongPuck.js
@@ -1,10 +1,15 @@
 let counter = 0;
 let connected = false;
 let controls = require("ble_hid_controls");
+let config = {
+  single: next,
+  double: playpause,
+  triple: previous,
+};
 
 NRF.setServices(undefined, { hid: controls.report });
 
-function single() {
+function next() {
   if (connected) {
     digitalWrite(LED3, true);
     setTimeout(function() { //Confirm with green blink
@@ -19,7 +24,7 @@ function single() {
   }
 }
 
-function double() {
+function playpause() {
   if (connected) {
     digitalWrite(LED3, true);
     setTimeout(function() {
@@ -34,7 +39,7 @@ function double() {
   }
 }
 
-function triple() {
+function previous() {
   if (connected) {
     digitalWrite(LED3, true);
     setTimeout(function() {
@@ -69,17 +74,19 @@ let watchID = setWatch(function buttonEvaluation() {
   let evalDuration = 600; //wait for 2nd or 3rd button press before evaluating counter
   counter++;
   setTimeout(() => {
-    if (counter === 3) {
-      triple();
-      counter = 0;
-    } else if (counter === 2) {
-      double();
-      counter = 0;
-    } else if (counter === 1) {
-      single();
-      counter = 0;
-    } else {
-      counter = 0;
+    switch (counter) {
+      case 3:
+        config.triple();
+      break;
+      case 2:
+        config.double();
+      break;
+      case 1:
+        config.single();
+      break;
     }
+    // Reset the counter once we're done.
+    counter = 0;
+
   }, evalDuration);
 }, BTN, { edge: "rising", debounce: 5, repeat: true });


### PR DESCRIPTION
I've made these changes, they're quite small:

- renamed the functions to be named after what they do, not how they're invoked
- allowed the functions to be easily rebound to different invocations 
- factor out common led flashing code

With my headphones I'm used to doing `single` for play/pause, `double` for next and `triple` for previous, so this way I can easily switch the functions called for `single` and `double`.


That being said, my Puck battery is dead (after sitting in my bag for a couple of months as a beacon!) so I've not been able to test that this actually all works, so if you decide to merge you should test it first :100:

Anyway, cheers!
